### PR TITLE
fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3442,9 +3442,9 @@
       }
     },
     "extract-files": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-6.0.0.tgz",
-      "integrity": "sha512-v9UVTPkERZR1NjEOIPvmbzLFdh8YZFEGjRdSJraop6HJe9PQ8HU9iv6eRMuF06CXXXO/R5OBmnWMixZHuZ8CsA=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-7.0.0.tgz",
+      "integrity": "sha512-3AUlT7TD+DbQXNe3t70QrgJU6Wgcp7rk1Zm0vqWz8OYnw4vxihgG0TgZ2SIGrVqScc4WfOu7B4a0BezGJ0YqvQ=="
     },
     "fast-deep-equal": {
       "version": "2.0.1",
@@ -4423,17 +4423,17 @@
       }
     },
     "graphql-tools-fork": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/graphql-tools-fork/-/graphql-tools-fork-8.2.0.tgz",
-      "integrity": "sha512-tFIB3WA8859YK5tPMAmizCT5BDFcbrFVYEdJbidzVz45BBEd324zgVof+m252f02DQg2ygW6IM2QSiThVCK6Pg==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/graphql-tools-fork/-/graphql-tools-fork-8.2.2.tgz",
+      "integrity": "sha512-xAx4UMXzNbaToLCKW9Dx+8HRRNV4Vx5yYTeAuWMQoj9iezXIWsEBKpRhcqc850r3vIm6vifNMKq5OjQ2N+svmg==",
       "requires": {
         "apollo-link": "^1.2.13",
         "apollo-link-http-common": "^0.2.15",
         "apollo-utilities": "^1.3.3",
         "deprecated-decorator": "^0.1.6",
-        "extract-files": "^6.0.0",
+        "extract-files": "^7.0.0",
         "form-data": "^3.0.0",
-        "iterall": "^1.2.2",
+        "iterall": "^1.3.0",
         "node-fetch": "^2.6.0",
         "uuid": "^3.3.3"
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "apollo-server-express": "^2.9.15",
     "dataloader": "^2.0.0",
     "graphql": "^14.5.8",
-    "graphql-tools-fork": "^8.2.0"
+    "graphql-tools-fork": "^8.2.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/src/app.js
+++ b/src/app.js
@@ -95,6 +95,7 @@ function dataloaders () {
           returnType: new GraphQLList(keys[0].info.returnType) // magic happening here
         }
       })
+      console.log(result) // in v8.2.2 shows results instead of promises to results
       return [...result.slice(0, keys.length)] // necessary only in this example because mocking does not return the correct result length.
     })
   }

--- a/src/app.js
+++ b/src/app.js
@@ -4,7 +4,7 @@ import {
   mergeSchemas,
   delegateToSchema
 } from 'graphql-tools-fork'
-import { graphql } from 'graphql'
+import { graphql, GraphQLList } from 'graphql'
 import DataLoader from 'dataloader'
 
 const taskSchema = makeExecutableSchema({
@@ -81,8 +81,8 @@ export const schema = mergeSchemas({
 
 function dataloaders () {
   return {
-    users: new DataLoader(async (keys) =>
-      delegateToSchema({
+    users: new DataLoader(async keys => {
+      const result = await delegateToSchema({
         schema: userSchema,
         operation: 'query',
         fieldName: 'usersByIds',
@@ -90,8 +90,13 @@ function dataloaders () {
           ids: keys.map(k => k.id)
         },
         context: null,
-        info: keys[0].info
-      }))
+        info: {
+          ...keys[0].info,
+          returnType: new GraphQLList(keys[0].info.returnType) // magic happening here
+        }
+      })
+      return [...result.slice(0, keys.length)] // necessary only in this example because mocking does not return the correct result length.
+    })
   }
 }
 


### PR DESCRIPTION
Delegating from a single object to a list of objects using dataloader works despite different info objects if info.returnType is manually wrapped with a GraphQLList.
Requesting a list of objects now yields a list of results rather than a list of promises to results; the latter will still occur (for now) when merging types asynchronously. See https://github.com/yaacovCR/graphql-tools-fork/issues/35